### PR TITLE
Added a flag to force web flow even with the venmo app installed locally...

### DIFF
--- a/venmo-sdk/Venmo.h
+++ b/venmo-sdk/Venmo.h
@@ -76,6 +76,14 @@ typedef void (^VENOAuthCompletionHandler)(BOOL success, NSError *error);
 
 
 /**
+ * Initiates Venmo OAuth request.
+ * @param permissions List of permissions.
+ * @param forceWebFlow Force webflow even with the venmo app installed in the user's phone
+ * @param completionHandler Completion handler to call upon returning from OAuth flow.
+ */
+- (void)requestPermissions:(NSArray *)permissions forcingWebFlow:(BOOL)forceWebFlow withCompletionHandler:(VENOAuthCompletionHandler)handler;
+
+/**
  * Returns a value indicating whether the access token should be refreshed.
  * @return YES if the session is open and the current date is later than the token's 
  * expiration date.

--- a/venmo-sdk/Venmo.m
+++ b/venmo-sdk/Venmo.m
@@ -96,21 +96,26 @@ static Venmo *sharedInstance = nil;
 
 - (void)requestPermissions:(NSArray *)permissions
      withCompletionHandler:(VENOAuthCompletionHandler)completionHandler {
+    [self requestPermissions:permissions forcingWebFlow:NO withCompletionHandler:completionHandler];
+}
+
+
+- (void)requestPermissions:(NSArray *)permissions forcingWebFlow:(BOOL)forceWebFlow withCompletionHandler:(VENOAuthCompletionHandler)completionHandler
+{
     NSString *scopeURLEncoded = [permissions componentsJoinedByString:@"%20"];
     self.OAuthCompletionHandler = completionHandler;
     self.session.state = VENSessionStateOpening;
-
+    
     NSString *baseURL;
-    if ([Venmo isVenmoAppInstalled]) {
+    if ([Venmo isVenmoAppInstalled] && !forceWebFlow) {
         baseURL = @"venmo://";
     } else {
         baseURL = [self baseURLPath];
     }
     NSURL *authURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@oauth/authorize?sdk=ios&client_id=%@&scope=%@&response_type=code", baseURL, self.appId, scopeURLEncoded]];
-
+    
     [[UIApplication sharedApplication] openURL:authURL];
 }
-
 
 - (BOOL)isSessionValid {
     NSDate *now = [NSDate date];


### PR DESCRIPTION
While integrating our app with the venmo sdk, we found that the native venmo app does not allow the user to switch to a different account when asking for credentials if there's already a valid venmo account set up. One of our use cases needs to allow the user to select more than one venmo accounts, so we need a way to allow him to select an account which is not his main venmo account. Until a workaround will be done in the venmo app (if that ever happens) which would consist in adding a "switch account" button.
