### PR TITLE
Make GTMStringEncoding ARC compliant

### DIFF
--- a/venmo-sdk.xcodeproj/project.pbxproj
+++ b/venmo-sdk.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		2D36011F1B8E421A0025196D /* libCMDQueryStringSerialization.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D36011E1B8E421A0025196D /* libCMDQueryStringSerialization.a */; };
 		2D3601211B8E42290025196D /* libSSKeychain.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D3601201B8E42290025196D /* libSSKeychain.a */; };
 		2D3601231B8E429E0025196D /* VENRequestDecoderSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D3601221B8E429E0025196D /* VENRequestDecoderSpec.m */; };
-		2D3601261B8E55930025196D /* GTMStringEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D3601241B8E55930025196D /* GTMStringEncoding.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2D3601261B8E55930025196D /* GTMStringEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D3601241B8E55930025196D /* GTMStringEncoding.m */; };
 		2D3601271B8E55930025196D /* GTMStringEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D3601251B8E55930025196D /* GTMStringEncoding.h */; };
 		2D3601291B8E592E0025196D /* GTMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D3601281B8E592E0025196D /* GTMDefines.h */; };
 		2D5EF54617EF41B100DDD15A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF54517EF41B100DDD15A /* Foundation.framework */; };

--- a/venmo-sdk/Encryption/GTMStringEncoding.m
+++ b/venmo-sdk/Encryption/GTMStringEncoding.m
@@ -89,22 +89,20 @@ GTM_INLINE int lcm(int a, int b) {
 }
 
 + (id)stringEncodingWithString:(NSString *)string {
-  return [[[self alloc] initWithString:string] autorelease];
+  return [[self alloc] initWithString:string];
 }
 
 - (id)initWithString:(NSString *)string {
   if ((self = [super init])) {
-    charMapData_ = [[string dataUsingEncoding:NSASCIIStringEncoding] retain];
+    charMapData_ = [string dataUsingEncoding:NSASCIIStringEncoding];
     if (!charMapData_) {
       _GTMDevLog(@"Unable to convert string to ASCII");
-      [self release];
       return nil;
     }
     charMap_ = (char *)[charMapData_ bytes];
     NSUInteger length = [charMapData_ length];
     if (length < 2 || length > 128 || length & (length - 1)) {
       _GTMDevLog(@"Length not a power of 2 between 2 and 128");
-      [self release];
       return nil;
     }
 
@@ -112,7 +110,6 @@ GTM_INLINE int lcm(int a, int b) {
     for (unsigned int i = 0; i < length; i++) {
       if (reverseCharMap_[(int)charMap_[i]] != kUnknownChar) {
         _GTMDevLog(@"Duplicate character at pos %d", i);
-        [self release];
         return nil;
       }
       reverseCharMap_[(int)charMap_[i]] = i;
@@ -124,11 +121,6 @@ GTM_INLINE int lcm(int a, int b) {
     padLen_ = lcm(8, shift_) / shift_;
   }
   return self;
-}
-
-- (void)dealloc {
-  [charMapData_ release];
-  [super dealloc];
 }
 
 - (NSString *)description {
@@ -217,8 +209,8 @@ GTM_INLINE int lcm(int a, int b) {
   _GTMDevAssert(outPos == outLen, @"Underflowed output buffer");
   [outData setLength:outPos];
 
-  return [[[NSString alloc] initWithData:outData
-                                encoding:NSASCIIStringEncoding] autorelease];
+  return [[NSString alloc] initWithData:outData
+                               encoding:NSASCIIStringEncoding];
 }
 
 - (NSString *)encodeString:(NSString *)inString {
@@ -282,8 +274,8 @@ GTM_INLINE int lcm(int a, int b) {
 
 - (NSString *)stringByDecoding:(NSString *)inString {
   NSData *ret = [self decode:inString];
-  return [[[NSString alloc] initWithData:ret
-                                encoding:NSUTF8StringEncoding] autorelease];
+  return [[NSString alloc] initWithData:ret
+                               encoding:NSUTF8StringEncoding];
 }
 
 @end


### PR DESCRIPTION
This causes problems when installing with CocoaPods. Alternatively, you could update the Podfile to specify which files need ARC, but this seems cleaner.