### PR TITLE
Use SafariViewController when it is available

### DIFF
--- a/venmo-sdk/Venmo.h
+++ b/venmo-sdk/Venmo.h
@@ -72,7 +72,7 @@ typedef void (^VENOAuthCompletionHandler)(BOOL success, NSError *error);
  * @param permissions List of permissions.
  * @param completionHandler Completion handler to call upon returning from OAuth flow.
  */
-- (void)requestPermissions:(NSArray *)permissions withCompletionHandler:(VENOAuthCompletionHandler)handler;
+- (void)requestPermissions:(NSArray *)permissions withCurrentViewController:(nullable UIViewController*)currentViewController withCompletionHandler:(nonnull VENOAuthCompletionHandler)handler;
 
 
 /**


### PR DESCRIPTION
For anyone that doesn't want to get stuck in review by the reason "Being taken to Safari is poor user experience".
More detail.

> 10.6 - Apple and our customers place a high value on simple, refined, creative, well thought through interfaces. They take more work but are worth it. Apple sets a high bar. If your user interface is complex or less than very good, it may be rejected

> 10.6 Details
> We also noticed that the user is taken to Safari to sign in or register for an account, which provides a poor user experience. Specifically, when a user connects their Venmo account, it triggers mobile Safari to do so. 
> We've attached screenshots for your reference. 

> Next Steps
> Please revise your app to enable users to sign in or register an account in the app. 
> We recommend implementing the Safari View Controller API to display web content within your app. The Safari View Controller allows the display of a URL and inspection of the certificate from an embedded browser in an app so that customers can verify the webpage URL and SSL certificate to confirm they are entering their sign in credentials into a legitimate page. 