### PR TITLE
Clean up Cocoapods usage

### DIFF
--- a/venmo-sdk.xcodeproj/project.pbxproj
+++ b/venmo-sdk.xcodeproj/project.pbxproj
@@ -7,13 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		178903B88018851AE34A92A6 /* libPods-venmo-sdk-integration-specs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EC62898F3A95FDA67595953 /* libPods-venmo-sdk-integration-specs.a */; };
 		2D5EF54617EF41B100DDD15A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF54517EF41B100DDD15A /* Foundation.framework */; };
 		2D5EF55517EF41B100DDD15A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF54517EF41B100DDD15A /* Foundation.framework */; };
 		2D5EF55A17EF41B100DDD15A /* libvenmo-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF54217EF41B100DDD15A /* libvenmo-sdk.a */; };
 		2D5EF56017EF41B100DDD15A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D5EF55E17EF41B100DDD15A /* InfoPlist.strings */; };
 		2D5EF5B517EF450E00DDD15A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF5B417EF450E00DDD15A /* UIKit.framework */; };
-		AB54A24207B8DF3B4A987885 /* libPods-venmo-sdk-specs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C41DB83550898B270C91642 /* libPods-venmo-sdk-specs.a */; };
+		8CDB74454ECE0417376DD13F /* libPods-venmo-sdk-specs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7578CAB8301D958A4865DE2C /* libPods-venmo-sdk-specs.a */; };
 		B611893A18A188AE0041AF50 /* VENPermissionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = B611893918A188AE0041AF50 /* VENPermissionConstants.h */; };
 		B62D59BC18973D71001E46A4 /* VENURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B62D59BA18973D71001E46A4 /* VENURLProtocol.h */; };
 		B62D59BD18973D71001E46A4 /* VENURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = B62D59BB18973D71001E46A4 /* VENURLProtocol.m */; };
@@ -48,7 +47,7 @@
 		B6588AFA18A0554200A0C73B /* VenmoSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = B6588AF918A0554200A0C73B /* VenmoSpec.m */; };
 		B6F5046618E38C2600BDACF7 /* VENPermission.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F5045F18E38C2600BDACF7 /* VENPermission.m */; };
 		B6F5046718E38C2600BDACF7 /* VENSession.m in Sources */ = {isa = PBXBuildFile; fileRef = B6F5046118E38C2600BDACF7 /* VENSession.m */; };
-		E108B4B80883664C6CF9BE6A /* libPods-venmo-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53C2F52D889AAC62B05EFFEC /* libPods-venmo-sdk.a */; };
+		C83CE2A59BB031026C82D882 /* libPods-venmo-sdk-integration-specs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 004E0D6601AEFA312FA7AA90 /* libPods-venmo-sdk-integration-specs.a */; };
 		EB3499BA190AF8D400C74EAA /* VENTransaction+VenmoSDKSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = B6B810A918A1842B00FD8955 /* VENTransaction+VenmoSDKSpec.m */; };
 		EB49E22C19266E0D008EA5DC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D5EF54517EF41B100DDD15A /* Foundation.framework */; };
 		EB49E23319266E0D008EA5DC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = EB49E23119266E0D008EA5DC /* InfoPlist.strings */; };
@@ -62,6 +61,7 @@
 		EBDCA6DE1911859900FDD5ED /* NSURL+VenmoSDKSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = EBDCA6DD1911859900FDD5ED /* NSURL+VenmoSDKSpec.m */; };
 		EBEAB6A6190ACA4700BA6322 /* VENTransaction+VenmoSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = EBEAB6A4190ACA4700BA6322 /* VENTransaction+VenmoSDK.h */; };
 		EBEAB6A7190ACA4700BA6322 /* VENTransaction+VenmoSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = EBEAB6A5190ACA4700BA6322 /* VENTransaction+VenmoSDK.m */; };
+		F923E1C348BA23BACE44FEE8 /* libPods-venmo-sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E1FD3900EA56C88B51F432DA /* libPods-venmo-sdk.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,7 +95,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1EC62898F3A95FDA67595953 /* libPods-venmo-sdk-integration-specs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk-integration-specs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		004E0D6601AEFA312FA7AA90 /* libPods-venmo-sdk-integration-specs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk-integration-specs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D5EF54217EF41B100DDD15A /* libvenmo-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libvenmo-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D5EF54517EF41B100DDD15A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		2D5EF55217EF41B100DDD15A /* venmo-sdk-specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "venmo-sdk-specs.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,13 +103,12 @@
 		2D5EF55D17EF41B100DDD15A /* venmo-sdk-specs-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "venmo-sdk-specs-Info.plist"; path = "Supporting Files/venmo-sdk-specs-Info.plist"; sourceTree = "<group>"; };
 		2D5EF55F17EF41B100DDD15A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2D5EF5B417EF450E00DDD15A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		3003853AD8A59F1850E09BCF /* Pods-venmo-sdk-integration-specs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-integration-specs.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs.debug.xcconfig"; sourceTree = "<group>"; };
-		3C41DB83550898B270C91642 /* libPods-venmo-sdk-specs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk-specs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		53C2F52D889AAC62B05EFFEC /* libPods-venmo-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		59FB70042C861AAFBC7DC14A /* Pods-venmo-sdk-integration-specs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-integration-specs.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs.release.xcconfig"; sourceTree = "<group>"; };
-		78DF2787C67E4B44B3B7CD8A /* Pods-venmo-sdk-specs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-specs.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs.release.xcconfig"; sourceTree = "<group>"; };
-		96A1AF6C8E4C8CFEDD4DF4B4 /* Pods-venmo-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk/Pods-venmo-sdk.release.xcconfig"; sourceTree = "<group>"; };
-		97836ED3BCA227A87043C1F4 /* Pods-venmo-sdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk/Pods-venmo-sdk.debug.xcconfig"; sourceTree = "<group>"; };
+		510F0726432616D68E29CCC9 /* Pods-venmo-sdk-specs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-specs.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs.debug.xcconfig"; sourceTree = "<group>"; };
+		7578CAB8301D958A4865DE2C /* libPods-venmo-sdk-specs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk-specs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7BCC0CEBE52DEBF579DA9CF2 /* Pods-venmo-sdk-integration-specs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-integration-specs.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs.release.xcconfig"; sourceTree = "<group>"; };
+		80403341DEEB22E806492C83 /* Pods-venmo-sdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk/Pods-venmo-sdk.release.xcconfig"; sourceTree = "<group>"; };
+		99A71299EF58438D03B3F658 /* Pods-venmo-sdk-specs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-specs.release.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs.release.xcconfig"; sourceTree = "<group>"; };
+		A0948B522131ACFFAE112FE0 /* Pods-venmo-sdk-integration-specs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-integration-specs.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs.debug.xcconfig"; sourceTree = "<group>"; };
 		B611893918A188AE0041AF50 /* VENPermissionConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENPermissionConstants.h; sourceTree = "<group>"; };
 		B611893B18A189800041AF50 /* VENSessionSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENSessionSpec.m; sourceTree = "<group>"; };
 		B62D59BA18973D71001E46A4 /* VENURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENURLProtocol.h; sourceTree = "<group>"; };
@@ -147,7 +146,7 @@
 		B6F5045F18E38C2600BDACF7 /* VENPermission.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENPermission.m; sourceTree = "<group>"; };
 		B6F5046018E38C2600BDACF7 /* VENSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VENSession.h; sourceTree = "<group>"; };
 		B6F5046118E38C2600BDACF7 /* VENSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VENSession.m; sourceTree = "<group>"; };
-		E2AAE4E354A2454A1828DEED /* Pods-venmo-sdk-specs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk-specs.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs.debug.xcconfig"; sourceTree = "<group>"; };
+		E1FD3900EA56C88B51F432DA /* libPods-venmo-sdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-venmo-sdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB3499BB190AF91500C74EAA /* venmo-sdk-specs-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "venmo-sdk-specs-Prefix.pch"; path = "Supporting Files/venmo-sdk-specs-Prefix.pch"; sourceTree = "<group>"; };
 		EB49E22A19266E0D008EA5DC /* venmo-sdk-integration-specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "venmo-sdk-integration-specs.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB49E23019266E0D008EA5DC /* venmo-sdk-integration-specs-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "venmo-sdk-integration-specs-Info.plist"; sourceTree = "<group>"; };
@@ -161,6 +160,7 @@
 		EBDCA6DD1911859900FDD5ED /* NSURL+VenmoSDKSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+VenmoSDKSpec.m"; sourceTree = "<group>"; };
 		EBEAB6A4190ACA4700BA6322 /* VENTransaction+VenmoSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "VENTransaction+VenmoSDK.h"; sourceTree = "<group>"; };
 		EBEAB6A5190ACA4700BA6322 /* VENTransaction+VenmoSDK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "VENTransaction+VenmoSDK.m"; sourceTree = "<group>"; };
+		F460659BE23E73705D09579F /* Pods-venmo-sdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-venmo-sdk.debug.xcconfig"; path = "Pods/Target Support Files/Pods-venmo-sdk/Pods-venmo-sdk.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,7 +170,7 @@
 			files = (
 				2D5EF5B517EF450E00DDD15A /* UIKit.framework in Frameworks */,
 				2D5EF54617EF41B100DDD15A /* Foundation.framework in Frameworks */,
-				E108B4B80883664C6CF9BE6A /* libPods-venmo-sdk.a in Frameworks */,
+				F923E1C348BA23BACE44FEE8 /* libPods-venmo-sdk.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -180,7 +180,7 @@
 			files = (
 				2D5EF55A17EF41B100DDD15A /* libvenmo-sdk.a in Frameworks */,
 				2D5EF55517EF41B100DDD15A /* Foundation.framework in Frameworks */,
-				AB54A24207B8DF3B4A987885 /* libPods-venmo-sdk-specs.a in Frameworks */,
+				8CDB74454ECE0417376DD13F /* libPods-venmo-sdk-specs.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -190,7 +190,7 @@
 			files = (
 				EBC4E5D61926917000E24E33 /* libvenmo-sdk.a in Frameworks */,
 				EB49E22C19266E0D008EA5DC /* Foundation.framework in Frameworks */,
-				178903B88018851AE34A92A6 /* libPods-venmo-sdk-integration-specs.a in Frameworks */,
+				C83CE2A59BB031026C82D882 /* libPods-venmo-sdk-integration-specs.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,7 +205,7 @@
 				EB49E22E19266E0D008EA5DC /* venmo-sdk-integration-specs */,
 				2D5EF54417EF41B100DDD15A /* Frameworks */,
 				2D5EF54317EF41B100DDD15A /* Products */,
-				E1503391841F4F7AC8B94B84 /* Pods */,
+				4F8256C164D23617F3D41F33 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -225,9 +225,9 @@
 				2D5EF5B417EF450E00DDD15A /* UIKit.framework */,
 				2D5EF54517EF41B100DDD15A /* Foundation.framework */,
 				2D5EF55317EF41B100DDD15A /* XCTest.framework */,
-				53C2F52D889AAC62B05EFFEC /* libPods-venmo-sdk.a */,
-				1EC62898F3A95FDA67595953 /* libPods-venmo-sdk-integration-specs.a */,
-				3C41DB83550898B270C91642 /* libPods-venmo-sdk-specs.a */,
+				E1FD3900EA56C88B51F432DA /* libPods-venmo-sdk.a */,
+				004E0D6601AEFA312FA7AA90 /* libPods-venmo-sdk-integration-specs.a */,
+				7578CAB8301D958A4865DE2C /* libPods-venmo-sdk-specs.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -278,6 +278,19 @@
 				2D5EF55E17EF41B100DDD15A /* InfoPlist.strings */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		4F8256C164D23617F3D41F33 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F460659BE23E73705D09579F /* Pods-venmo-sdk.debug.xcconfig */,
+				80403341DEEB22E806492C83 /* Pods-venmo-sdk.release.xcconfig */,
+				A0948B522131ACFFAE112FE0 /* Pods-venmo-sdk-integration-specs.debug.xcconfig */,
+				7BCC0CEBE52DEBF579DA9CF2 /* Pods-venmo-sdk-integration-specs.release.xcconfig */,
+				510F0726432616D68E29CCC9 /* Pods-venmo-sdk-specs.debug.xcconfig */,
+				99A71299EF58438D03B3F658 /* Pods-venmo-sdk-specs.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		B62D59B918973D71001E46A4 /* URL Handling */ = {
@@ -339,19 +352,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		E1503391841F4F7AC8B94B84 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				97836ED3BCA227A87043C1F4 /* Pods-venmo-sdk.debug.xcconfig */,
-				96A1AF6C8E4C8CFEDD4DF4B4 /* Pods-venmo-sdk.release.xcconfig */,
-				3003853AD8A59F1850E09BCF /* Pods-venmo-sdk-integration-specs.debug.xcconfig */,
-				59FB70042C861AAFBC7DC14A /* Pods-venmo-sdk-integration-specs.release.xcconfig */,
-				E2AAE4E354A2454A1828DEED /* Pods-venmo-sdk-specs.debug.xcconfig */,
-				78DF2787C67E4B44B3B7CD8A /* Pods-venmo-sdk-specs.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		EB49E22E19266E0D008EA5DC /* venmo-sdk-integration-specs */ = {
 			isa = PBXGroup;
 			children = (
@@ -408,13 +408,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2D5EF56517EF41B100DDD15A /* Build configuration list for PBXNativeTarget "venmo-sdk" */;
 			buildPhases = (
-				E6F4AF0A56E5F63E70B39298 /* Check Pods Manifest.lock */,
+				3D35FCABDB84B1BF733CE4E5 /* Check Pods Manifest.lock */,
 				2D5EF53E17EF41B100DDD15A /* Sources */,
 				2D5EF53F17EF41B100DDD15A /* Frameworks */,
 				2D5EF56C17EF42BE00DDD15A /* Headers */,
 				2D5EF54017EF41B100DDD15A /* Copy Files */,
 				2D5EF56E17EF43E900DDD15A /* ShellScript */,
-				C34668A62208DD4B9113BB36 /* Copy Pods Resources */,
+				86FA44EDF2C2C1A3D40994A5 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -429,11 +429,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2D5EF56817EF41B100DDD15A /* Build configuration list for PBXNativeTarget "venmo-sdk-specs" */;
 			buildPhases = (
-				D2F43659B449516DD06FBD61 /* Check Pods Manifest.lock */,
+				49AE3B412BF8A5131BD2FAD5 /* Check Pods Manifest.lock */,
 				2D5EF54E17EF41B100DDD15A /* Sources */,
 				2D5EF54F17EF41B100DDD15A /* Frameworks */,
 				2D5EF55017EF41B100DDD15A /* Resources */,
-				7374F45841F24BED1351194B /* Copy Pods Resources */,
+				73FF35D111259250430DD83B /* Embed Pods Frameworks */,
+				085D6AFC716A4CD08502A42B /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -449,11 +450,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EB49E23B19266E0D008EA5DC /* Build configuration list for PBXNativeTarget "venmo-sdk-integration-specs" */;
 			buildPhases = (
-				194AF32794C1483184C93024 /* Check Pods Manifest.lock */,
+				811B69E18D8F1D52755E85F2 /* Check Pods Manifest.lock */,
 				EB49E22619266E0D008EA5DC /* Sources */,
 				EB49E22719266E0D008EA5DC /* Frameworks */,
 				EB49E22819266E0D008EA5DC /* Resources */,
-				2BF59B2DD4882A77B45CC6AD /* Copy Pods Resources */,
+				79C1C57DBCCF70AC431CDF75 /* Embed Pods Frameworks */,
+				ECAF0525302A9E8858DFC2D0 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -519,22 +521,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		194AF32794C1483184C93024 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		2BF59B2DD4882A77B45CC6AD /* Copy Pods Resources */ = {
+		085D6AFC716A4CD08502A42B /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -546,7 +533,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		2D5EF56E17EF43E900DDD15A /* ShellScript */ = {
@@ -562,22 +549,82 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nmkdir -p \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/A/Headers\"\n\n# Link the \"Current\" version to \"A\"\n/bin/ln -sfh A \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/Current\"\n/bin/ln -sfh Versions/Current/Headers \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Headers\"\n/bin/ln -sfh \"Versions/Current/${PRODUCT_NAME}\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/${PRODUCT_NAME}\"\n\n# The -a ensures that the headers maintain the source modification date so that we don't constantly\n# cause propagating rebuilds of files that import these headers.\n/bin/cp -a \"${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}/\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/A/Headers\"\n";
 		};
-		7374F45841F24BED1351194B /* Copy Pods Resources */ = {
+		3D35FCABDB84B1BF733CE4E5 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		C34668A62208DD4B9113BB36 /* Copy Pods Resources */ = {
+		49AE3B412BF8A5131BD2FAD5 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		73FF35D111259250430DD83B /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-specs/Pods-venmo-sdk-specs-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		79C1C57DBCCF70AC431CDF75 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		811B69E18D8F1D52755E85F2 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		86FA44EDF2C2C1A3D40994A5 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -592,34 +639,19 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk/Pods-venmo-sdk-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D2F43659B449516DD06FBD61 /* Check Pods Manifest.lock */ = {
+		ECAF0525302A9E8858DFC2D0 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E6F4AF0A56E5F63E70B39298 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-venmo-sdk-integration-specs/Pods-venmo-sdk-integration-specs-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -783,7 +815,7 @@
 		};
 		2D5EF56617EF41B100DDD15A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 97836ED3BCA227A87043C1F4 /* Pods-venmo-sdk.debug.xcconfig */;
+			baseConfigurationReference = F460659BE23E73705D09579F /* Pods-venmo-sdk.debug.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/Venmo.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -802,7 +834,7 @@
 		};
 		2D5EF56717EF41B100DDD15A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 96A1AF6C8E4C8CFEDD4DF4B4 /* Pods-venmo-sdk.release.xcconfig */;
+			baseConfigurationReference = 80403341DEEB22E806492C83 /* Pods-venmo-sdk.release.xcconfig */;
 			buildSettings = {
 				DSTROOT = /tmp/Venmo.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -821,7 +853,7 @@
 		};
 		2D5EF56917EF41B100DDD15A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E2AAE4E354A2454A1828DEED /* Pods-venmo-sdk-specs.debug.xcconfig */;
+			baseConfigurationReference = 510F0726432616D68E29CCC9 /* Pods-venmo-sdk-specs.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -842,7 +874,7 @@
 		};
 		2D5EF56A17EF41B100DDD15A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 78DF2787C67E4B44B3B7CD8A /* Pods-venmo-sdk-specs.release.xcconfig */;
+			baseConfigurationReference = 99A71299EF58438D03B3F658 /* Pods-venmo-sdk-specs.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -859,7 +891,7 @@
 		};
 		EB49E23919266E0D008EA5DC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3003853AD8A59F1850E09BCF /* Pods-venmo-sdk-integration-specs.debug.xcconfig */;
+			baseConfigurationReference = A0948B522131ACFFAE112FE0 /* Pods-venmo-sdk-integration-specs.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -882,7 +914,7 @@
 		};
 		EB49E23A19266E0D008EA5DC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 59FB70042C861AAFBC7DC14A /* Pods-venmo-sdk-integration-specs.release.xcconfig */;
+			baseConfigurationReference = 7BCC0CEBE52DEBF579DA9CF2 /* Pods-venmo-sdk-integration-specs.release.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
This is the result of a `pod deintegrate` followed by a `pod install`. This will remove implementations from old Cocoapods versions and update us to the latest integration from Cocoapods.