### PR TITLE
modify requestPermissions method to open SFSafariViewController 

### DIFF
--- a/venmo-sdk/Venmo.h
+++ b/venmo-sdk/Venmo.h
@@ -72,7 +72,9 @@ typedef void (^VENOAuthCompletionHandler)(BOOL success, NSError *error);
  * @param permissions List of permissions.
  * @param completionHandler Completion handler to call upon returning from OAuth flow.
  */
-- (void)requestPermissions:(NSArray *)permissions withCompletionHandler:(VENOAuthCompletionHandler)handler;
+- (void)requestPermissions:(NSArray *)permissions
+        fromViewController:(UIViewController *)viewController
+     withCompletionHandler:(VENOAuthCompletionHandler)handler;
 
 
 /**


### PR DESCRIPTION
Pull request title: modify requestPermissions method to open SFSafariViewController to comply with AppStore requirements

Comment: Apple testers rejected an app that uses Venmo API, because authorization request session currently opens in Safari browser. Apple testers think that it is a bad user experience and required to implement it using SFSafariViewController instead, so a user doesn't have to leave an app to authorize access to their Venmo account. 
